### PR TITLE
Backend - Add Image Scan Middleware to ImageController 

### DIFF
--- a/backend/.grype/config.yaml
+++ b/backend/.grype/config.yaml
@@ -1,1 +1,0 @@
-default-image-pull-source: "docker"

--- a/backend/backend-types.d.ts
+++ b/backend/backend-types.d.ts
@@ -93,11 +93,11 @@ export interface NetworkListModalProps {
 // Server-Side Typing
 // ==========================================================
 export interface ServerError {
-  log: string;
-  status: number;
-  message: {
+  log: {
     err: string;
   };
+  status: number;
+  message: string
 };
 
 export interface ContainerNetworkObject {
@@ -120,4 +120,23 @@ export interface MetricsQuery {
   block_io: string;
   pid: string;
   created_at: Date;
+}
+
+// ==============================================
+// BACKEND IMAGE TYPES
+// ==============================================
+//Data generated from running GrypeScan on imageControllers.scanImages
+export interface GrypeScan {
+  Package: string;
+  'Version Installed'?: string;
+  'Vulnerability ID'?: string;
+  Severity?: string;
+}
+
+export interface countVulnerability {
+  Negligible?: number;
+  Low?: number;
+  Medium?: number;
+  High?: number;
+  Critical?: number;
 }

--- a/backend/controllers/docker/containersController.ts
+++ b/backend/controllers/docker/containersController.ts
@@ -94,12 +94,12 @@ containerController.getContainers = async (req: Request, res: Response, next: Ne
     res.locals.containers = containers;
     return next();
   } catch (error) {
-    const errObj = {
-      log: JSON.stringify({ 'containerController.getContainers Error: ': error }),
+    const errObj: ServerError = {
+      log: { err: `containerController.getContainers Error: ${error}` },
       status: 500,
-      message: { err: 'containerController.getContainers error' }
-    };
-    return next(errObj);
+      message: 'internal server error'
+    }
+    next(errObj);
   }
 }
 
@@ -111,12 +111,12 @@ containerController.getStoppedContainers = async (req: Request, res: Response, n
     res.locals.containers = containers;
     return next();
   } catch (error) {
-    const errObj = {
-      log: JSON.stringify({ 'containerController.getStoppedContainers Error: ': error }),
+    const errObj: ServerError = {
+      log: { err: `containerController.getStoppedContainers  Error: ${error}` },
       status: 500,
-      message: { err: 'containerController.getStoppedContainers error' }
-    };
-    return next(errObj);
+      message: 'internal server error'
+    }
+    next(errObj);
   }
 }
 
@@ -128,13 +128,12 @@ containerController.bashContainer = async (req: Request, res: Response, next: Ne
     if (stderr.length) throw new Error(stderr);
     return next()
   } catch (error) {
-    console.log('Oh no, no bash')
-    const errObj = {
-      log: JSON.stringify({ 'containerController.bashContainer Error: ': error }),
+    const errObj: ServerError = {
+      log: { err: `containerController.bashContainer  Error: ${error}` },
       status: 500,
-      message: { err: 'containerController.bashContainer error' }
-    };
-    return next(errObj);
+      message: 'internal server error'
+    }
+    next(errObj);
   }
 }
 
@@ -146,33 +145,15 @@ containerController.runContainer = async (req: Request, res: Response, next: Nex
     if (stderr.length) throw new Error(stderr);
     return next();
   } catch (error) {
-    const errObj = {
-      log: JSON.stringify({ 'containerController.runContainer Error: ': error }),
+    const errObj: ServerError = {
+      log: { err: `containerController.runContainer  Error: ${error}` },
       status: 500,
-      message: { err: 'containerController.runContainer error' }
-    };
-    return next(errObj);
+      message: 'internal server error'
+    }
+    next(errObj);
   }
 },
-  containerController.bashContainer = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-  console.log(req.body)
-    console.log(req.params)
-  try {
-    console.log('You have bashed')
-    const { id } = req.body;
-    const { stdout, stderr } = await execAsync(`docker exec -it ${id} /bin/sh`)
-    return next()
-  } catch (error) {
-    console.log('Oh no, no bash')
-    const errObj = {
-      log: JSON.stringify({ 'containerController.bashContainer Error: ': error }),
-      status: 500,
-      message: { err: 'containerController.bashContainer error' }
-    };
-    return next(errObj);
-  }
-},
-
+  
 containerController.stopContainer = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { id } = req.body;
@@ -180,12 +161,12 @@ containerController.stopContainer = async (req: Request, res: Response, next: Ne
     if (stderr.length) throw new Error(stderr);
     return next();
   } catch (error) {
-    const errObj = {
-      log: JSON.stringify({ 'containerController.stopContainer Error: ': error }),
+    const errObj: ServerError = {
+      log: { err: `containerController.stopContainer  Error: ${error}` },
       status: 500,
-      message: { err: 'containerController.stopContainer error' }
-    };
-    return next(errObj);
+      message: 'internal server error'
+    }
+    next(errObj);
   }
 }
 
@@ -199,12 +180,12 @@ containerController.removeContainer = async (req: Request, res: Response, next: 
     console.log(stdout);
     return next();
   } catch (error) {
-    const errObj = {
-      log: JSON.stringify({ 'containerController.removeContainer Error: ': error }),
+    const errObj: ServerError = {
+      log: { err: `containerController.removeContainer  Error: ${error}` },
       status: 500,
-      message: { err: 'containerController.removeContainer error' }
-    };
-    return next(errObj);
+      message: 'internal server error'
+    }
+    next(errObj);
   }
 }
 
@@ -245,9 +226,9 @@ containerController.getAllLogs = async (req: Request<unknown, unknown, unknown, 
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'containerController.getAllLogs Error: ': error }),
+      log: { err: `containerController.getAllLogs Error: ${error}` },
       status: 500,
-      message: { err: 'containerController.getAllLogs Error retrieving logs' }
+      message: 'internal server error'
     }
     return next(errObj);
   }
@@ -276,9 +257,9 @@ containerController.inspectContainer = async (req: Request, res: Response, next:
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'containerController.inspectContainer Error: ': error }),
+      log: { err: `containerController.inspectContainer Error: ${error}` },
       status: 500,
-      message: { err: 'containerController.inspectContainer Error retrieving logs' }
+      message: 'internal server error'
     }
     return next(errObj);
   }

--- a/backend/controllers/docker/imagesController.ts
+++ b/backend/controllers/docker/imagesController.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import { ContainerPS, ImageType } from '../../../types';
 import { execAsync } from '../helper';
 import { ServerError } from '../../backend-types';
+import { log } from 'console';
 
 interface ImageController {
   /**
@@ -66,9 +67,15 @@ imageController.getImages = async (req: Request, res: Response, next: NextFuncti
 
 imageController.scanImages = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
-    const { stdout, stderr } = await execAsync('grype version');
-    if (stderr) throw new Error(stderr);
-    const CVEInfo = stdout; 
+    console.log('scanning images');
+    
+    const execArray = [execAsync('GRYPE_DB_AUTO_UPDATE=false; grype mysql'), execAsync('GRYPE_DB_AUTO_UPDATE=false; grype postgres')]
+    // const { stdout, stderr } = await execAsync('grype mysql');
+    console.log('execArray', execArray);
+    console.log('type of execArray', typeof execArray);
+    const resultArr = await Promise.all(execArray);
+    // if (stderr) throw new Error(stderr);
+    const CVEInfo = JSON.stringify(resultArr); 
     console.log('Image Vulnerability Info', CVEInfo);
     res.locals.CVEInfo = CVEInfo;
     next()

--- a/backend/controllers/docker/networksController.ts
+++ b/backend/controllers/docker/networksController.ts
@@ -77,9 +77,9 @@ networkController.getNetworks = async (req: Request, res: Response, next: NextFu
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'networkController.getNetworks Error: ': error }),
+      log: { err: `networkController.getNetworks Error: ${error}` },
       status: 500,
-      message: { err: 'networkController.getNetworks error' }
+      message: 'internal server error'
     }
     return next(errObj);
   }
@@ -96,10 +96,11 @@ networkController.createNetwork = async (req: Request, res: Response, next: Next
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'networkController.createNetwork Error: ': error }),
+      log: { err: `networkController.createNetworks Error: ${error}` },
       status: 500,
-      message: { err: 'networkController.createNetwork error' }
+      message: 'internal server error'
     }
+    
     return next(errObj);
   }
 }
@@ -116,9 +117,9 @@ networkController.removeNetwork = async (req: Request, res: Response, next: Next
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'networkController.removeNetwork Error: ': error }),
+      log: { err: `networkController.removeNetworks Error: ${error}` },
       status: 500,
-      message: { err: 'networkController.removeNetwork error' }
+      message: 'internal server error'
     }
     return next(errObj);
   }
@@ -135,9 +136,9 @@ networkController.connectContainerToNetwork = async (req: Request, res: Response
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'networkController.connectContainerToNetwork Error: ': error }),
+      log: { err: `networkController.connectContainerToNetwork Error: ${error}` },
       status: 500,
-      message: { err: 'networkController.connectContainerToNetwork error' }
+      message: 'internal server error'
     }
     return next(errObj);
   }
@@ -154,9 +155,9 @@ networkController.disconnectContainerFromNetwork = async (req: Request, res: Res
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'networkController.disconnectContainerFromNetwork Error: ': error }),
+      log: { err: `networkController.disconnectContainerFromNetwork Error: ${error}` },
       status: 500,
-      message: { err: 'networkController.disconnectContainerFromNetwork error' }
+      message: 'internal server error'
     }
     return next(errObj);
   }
@@ -178,9 +179,9 @@ networkController.getContainersOnNetwork = async (req: Request, res: Response, n
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'networkController.getContainersOnNetwork Error: ': error }),
+      log: { err: `networkController.getContainersOnNetwork Error: ${error}` },
       status: 500,
-      message: { err: 'networkController.getContainersOnNetwork error' }
+      message: 'internal server error'
     }
     return next(errObj);
   }
@@ -199,9 +200,9 @@ networkController.prune = async (req: Request, res: Response, next: NextFunction
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'networkController.prune Error: ': error }),
+      log: { err: `networkController.prune Error: ${error}` },
       status: 500,
-      message: { err: 'networkController.prune error' }
+      message: 'internal server error'
     }
     return next(errObj);
   }

--- a/backend/controllers/docker/systemController.ts
+++ b/backend/controllers/docker/systemController.ts
@@ -25,11 +25,11 @@ systemController.prune = async (req: Request, res: Response, next: NextFunction)
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'systemController.prune Error: ': error }),
+      log: { err: `systemController.prune Error: ${error}` },
       status: 500,
-      message: { err: 'systemController.prune error' }
+      message: 'internal server error'
     }
-    return next(errObj);
+    next(errObj);
   }
 }
 export default systemController;

--- a/backend/controllers/docker/volumesController.ts
+++ b/backend/controllers/docker/volumesController.ts
@@ -41,11 +41,11 @@ volumeController.getContainersOnVolume = async(req: Request, res: Response, next
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'volumeController.getContainersOnVolume Error: ': error }),
+      log: { err: `volumeController.getContainersOnVolume Error: ${error}` },
       status: 500,
-      message: { err: 'volumeController.getContainersOnVolume error' }
+      message: 'internal server error'
     }
-    return next(errObj);
+    next(errObj);
   }
 }
 
@@ -58,11 +58,11 @@ volumeController.getVolumes = async (req: Request, res: Response, next: NextFunc
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'volumeController.getVolumes Error: ': error }),
+      log: { err: `volumeController.getVolumes Error: ${error}` },
       status: 500,
-      message: { err: 'volumeController.getVolumes error' }
+      message: 'internal server error'
     }
-    return next(errObj);
+    next(errObj);
   }
 }
 
@@ -77,11 +77,11 @@ volumeController.removeVolume = async(req: Request, res: Response, next: NextFun
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'volumeController.removeVolume Error: ': error }),
+      log: { err: `volumeController.removeVolume Error: ${error}` },
       status: 500,
-      message: { err: 'volumeController.removeVolume error' }
+      message: 'internal server error'
     }
-    return next(errObj);
+    next(errObj);
   }
 }
 

--- a/backend/controllers/prometheus/configController.ts
+++ b/backend/controllers/prometheus/configController.ts
@@ -58,10 +58,10 @@ configController.getTypeOptions = async (req: Request, res: Response, next: Next
 
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'configController.getTypeOptions Error: ': error }),
+      log: { err: `configController.getTypeOptions Error: ${error}` },
       status: 500,
-      message: { err: 'configController.getTypeOptions error' }
-    };
+      message: 'internal server error'
+    }
     return next(errObj); 
   }
 } 
@@ -80,10 +80,10 @@ configController.getDataSources = async (req: Request, res: Response, next: Next
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'configController.getDataSources Error: ': error }),
+      log: { err: `configController.getDataSources Error: ${error}` },
       status: 500,
-      message: { err: 'configController.getDataSources error' }
-    };
+      message: 'internal server error'
+    }
     return next(errObj);
   }
 }
@@ -102,12 +102,11 @@ configController.createDataSource = async (req: Request, res: Response, next: Ne
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'configController.createDataSource Error: ': error }),
+      log: { err: `configController.createDataSource Error: ${error}` },
       status: 500,
-      message: { err: 'configController.createDataSource error' }
-    };
+      message: 'internal server error'
+    }
     return next(errObj);
-    
   }
 }
 
@@ -123,10 +122,10 @@ configController.updateDataSource = async (req: Request, res: Response, next: Ne
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'configController.updateDataSource Error: ': error }),
+      log: { err: `configController.updateDataSource Error: ${error}` },
       status: 500,
-      message: { err: 'configController.updateDataSource error' }
-    };
+      message: 'internal server error'
+    }
     return next(errObj);
 
   }
@@ -142,12 +141,11 @@ configController.deleteDataSource = async (req: Request, res: Response, next: Ne
     return next();
   } catch (error) {
     const errObj: ServerError = {
-      log: JSON.stringify({ 'configController.deleteDataSource Error: ': error }),
+      log: { err: `configController.deleteDataSource Error: ${error}` },
       status: 500,
-      message: { err: 'configController.deleteDataSource error' }
-    };
+      message: 'internal server error'
+    }
     return next(errObj);
-
   }
 }
 export default configController;

--- a/backend/routers/docker/imageRouter.ts
+++ b/backend/routers/docker/imageRouter.ts
@@ -10,7 +10,7 @@ const router = Router();
  * @param 
  * @returns
  */
-router.get('/', imageController.getImages, imageController.scanImages, (req, res) => {
+router.get('/', imageController.getImages, (req, res) => {
   return res.status(200).json(res.locals.images);
 });
 
@@ -19,6 +19,20 @@ router.get('/', imageController.getImages, imageController.scanImages, (req, res
  * @todo 
  * @param 
  * @returns
+ */
+router.post('/scan', imageController.scanImages, (req, res) => {
+  return res.status(200).json(res.locals.vulnerabilites);
+});
+
+/**
+ * @abstract Scans an using Grype CLI and summarizes the report's vulnerabilities by severity
+ * @todo 
+ * @param req.body.scanName
+ * @returns count of vulnerabilities in this format: {
+    "Low": 19,
+    "Medium": 11,
+    "Negligible": 3
+}
  */
 router.get('/:id');
 

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -62,10 +62,11 @@ app.use(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   (err: ServerError, req: Request, res: Response, next: NextFunction): Response => {
     const defaultErr: ServerError = {
-      log: 'Express error handler caught unknown middleware error',
+      log: {err:'Express error handler caught unknown middleware error'},
       status: 500,
-      message: { err: 'An error occurred' },
+      message: 'internal server error',
     };
+
     const errorObj: ServerError = Object.assign({}, defaultErr, err);
     console.log(errorObj.log);
     return res.status(errorObj.status).json(errorObj.message);

--- a/types.d.ts
+++ b/types.d.ts
@@ -86,6 +86,7 @@ export interface ImageType{
   ID: string;
   Repository: string;
   SharedSize?: string;
+  ScanName?: string;
   Size: string;
   Tag: string;
   UniqueSize?: string;


### PR DESCRIPTION
Changes:
1. POST requests to `/api/docker/image/scan` endpoint return a JSON summary of vulnerabilities for selected scanned image
2. Added a custom Go template in /backend/controllers/grype/json.tmpl to format the Grype data
3. Corrected all ServerError types across all controller files so that private server errors are not being displayed to the user

