### PR TITLE
Optimize grype fetching & Update dockerfile.prod for functional production image

### DIFF
--- a/backend/routers/docker/imageRouter.ts
+++ b/backend/routers/docker/imageRouter.ts
@@ -1,7 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import imageController from '../../controllers/docker/imagesController';
-import containerController from '../../controllers/docker/containersController';
-import { log } from 'console';
 const router = Router();
 
 /**
@@ -10,7 +8,8 @@ const router = Router();
  * @param 
  * @returns
  */
-router.get('/', imageController.getImages, (req, res) => {
+router.get('/', imageController.getImages, imageController.dbStatus, (req, res) => {
+  console.log('db status', res.locals.dbStatus);
   return res.status(200).json(res.locals.images);
 });
 

--- a/extension/dev.Dockerfile
+++ b/extension/dev.Dockerfile
@@ -64,6 +64,8 @@ RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${
 
 #install grype to run image vulnerability scans
 RUN curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+# Build and update the grype db
+RUN grype db update
 
 # Copies necessary files into extension directory
 COPY --from=builder /backend backend

--- a/extension/dockerfile.prod
+++ b/extension/dockerfile.prod
@@ -73,6 +73,8 @@ RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${
 
 #install grype to run image vulnerability scans
 RUN curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+# Build and update the grype db
+RUN grype db update
 
 # Copies necessary files into extension directory
 # COPY extension/docker-compose-prod.yaml ./docker-compose.yaml

--- a/extension/dockerfile.prod
+++ b/extension/dockerfile.prod
@@ -3,6 +3,10 @@ FROM --platform=$BUILDPLATFORM node:18.12-alpine3.16 AS builder
 WORKDIR /
 COPY types.d.ts .
 COPY tsconfig.json .
+
+# Copies the backend package.json files
+# Generates the /dist folder with compiled javascript from ts
+# configures npm to use a cached directory for node_modules to speed up build process
 WORKDIR /backend
 COPY backend/package*.json .
 RUN --mount=type=cache,target=/usr/src/app/.npm \
@@ -10,6 +14,11 @@ RUN --mount=type=cache,target=/usr/src/app/.npm \
     npm ci
 COPY backend/. .
 RUN npm run build
+
+# Create a go template file inside /backend/dist/controllers/grype
+# This template is used for the output of vulnerability information
+WORKDIR /backend/dist/controllers/grype
+RUN echo '[{{- range $index, $match := .Matches}}{{if $index}},{{end}}{"Package": "{{.Artifact.Name}}","Version Installed": "{{.Artifact.Version}}","Vulnerability ID": "{{.Vulnerability.ID}}","Severity": "{{.Vulnerability.Severity}}"}{{- end}}]' > json.tmpl
 
 # Builds everything in UI folder
 FROM --platform=$BUILDPLATFORM node:18.12-alpine3.16 AS client-builder
@@ -66,9 +75,11 @@ RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${
 RUN curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
 
 # Copies necessary files into extension directory
-COPY extension/docker-compose-prod.yaml ./docker-compose.yaml
+# COPY extension/docker-compose-prod.yaml ./docker-compose.yaml
+COPY extension/docker-compose-prod.yaml docker-compose.yaml
 WORKDIR /extension
 COPY backend/db/init_prod.sql /extension/.
+
 WORKDIR /
 COPY metadata.json .
 COPY docketeer.svg .

--- a/ui/src/components/ImageCard/ImageCard.tsx
+++ b/ui/src/components/ImageCard/ImageCard.tsx
@@ -14,20 +14,32 @@ import Client from '../../models/Client';
 function ImageCard({ imgObj, runImageAlert, removeImageAlert }: ImageCardProps): React.JSX.Element {
 
 	// initialize state variable to store vulnerabilities
-	const [scanObj, setScanObj] = useState({})
+	const [scanObj, setScanObj] = useState({
+    Critical: '-',
+    High: '-',
+    Medium: '-',
+    Low: '-',
+  });
 
-	const getScan = async (scanName: string) => { 
-		// check if an image tag is <none>, and if it is, call getScan on this image - this is because scanning an Unused(dangling) image returns an error
-		if (imgObj.Tag === "<none>") {
-			setScanObj({ Critical: '-', High: '-', Medium: '-', Low: '-' })
+	const getScan = async (scanName: string) => {
+    // check if an image tag is <none>, and if it is, call getScan on this image - this is because scanning an Unused(dangling) image returns an error
+    if (imgObj.Tag === '<none>') {
+      setScanObj({ Critical: '-', High: '-', Medium: '-', Low: '-' });
+      return;
+    }
+
+    try {
+      // retrieve scan data - Client.ImageService.getScan creates DDClient Request
+      const success = await Client.ImageService.getScan(scanName);
+      console.log(`Success from getScan: ${scanName}`, success);
+
+      // set state with scan data
+			setScanObj(success);
 			return;
-		}
-		// retrieve scan data - Client.ImageService.getScan creates DDClient Request
-    const success = await Client.ImageService.getScan(scanName);
-		console.log(`Success from getScan: ${scanName}`, success);
-
-		// set state with scan data
-		setScanObj(success)
+    } catch (error) {
+      // Log error if failed
+      console.log('getScan has failed to get vulnerabilities: ', error);
+    }
   }
 
 	// call getScan upon render for each card


### PR DESCRIPTION
**Production Image**
- Create json.tmpl file with a RUN command inside dockerfile.prod
- Before this change, the template file was not being copied correctly in the production image

**imagesController**
-  scanImages: Store path to the json.tmpl file on templatePath variable
- dbStatus: middleware to update the grype database. Executed when images are fetched, after the getImages middleware.